### PR TITLE
Dependency Gem Upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 PATH
   remote: .
   specs:
-    jaspersoft (0.0.3)
-      sawyer (~> 0.5.1)
+    jaspersoft (0.0.7)
+      sawyer (~> 0.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
+    addressable (2.4.0)
     diff-lcs (1.2.3)
-    faraday (0.8.8)
-      multipart-post (~> 1.2.0)
-    multipart-post (1.2.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    multipart-post (2.0.0)
     rake (10.0.4)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
@@ -21,8 +21,8 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    sawyer (0.5.1)
-      addressable (~> 2.3.5)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
 
 PLATFORMS
@@ -33,3 +33,6 @@ DEPENDENCIES
   jaspersoft!
   rake
   rspec
+
+BUNDLED WITH
+   1.11.2

--- a/jaspersoft.gemspec
+++ b/jaspersoft.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sawyer', '~> 0.5.1'
+  spec.add_dependency 'sawyer', '~> 0.7.0'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/jaspersoft/version.rb
+++ b/lib/jaspersoft/version.rb
@@ -1,5 +1,5 @@
 module Jaspersoft
 
-  VERSION = "0.0.7".freeze
+  VERSION = "0.0.8".freeze
 
 end


### PR DESCRIPTION
Made changes in jaspersoft so that able to update metainspector gem(Phoenix) 2.2.1 to 5.0.1.
Addressable and faraday were dependent for matainspector gem.
Sawyer and launchy having dependency gem addressable. To make usse updated version of addressable updated sawyer and launchy..! 
